### PR TITLE
Remove unnecessary tag in manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="su.levenetc.android.textsurface">
 
-    <application android:allowBackup="true" android:label="@string/app_name">
-
-    </application>
-
 </manifest>
+


### PR DESCRIPTION
Manifest merge error has occurred.

```
  1 Error:Execution failed for task ':myapp:processDebugManifest'.
  2 > Manifest merger failed : Attribute application@label value=(My app name) from AndroidManifest.xml:33:5-32
  3     is also present at [com.github.elevenetc:textsurface:0.9.1] AndroidManifest.xml:13:9-41 value=(@string/app_name)
  4         Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:7:3-10:7 to

```

Can you merge?
